### PR TITLE
Check that hospital ID is present before requesting waits.

### DIFF
--- a/clockwiseWaitTimes.js
+++ b/clockwiseWaitTimes.js
@@ -72,8 +72,10 @@ function beginWaitTimeQuerying(waitFetchObjects, timeBetweenUpdates) {
     var waitKeys = Object.keys(clusteredWaits),
         currentCluster, queryUrl;
     for(var i = 0; i < waitKeys.length; i++) {
-      currentCluster = clusteredWaits[waitKeys[i]];
-      queryUrl = 'https://api.clockwisemd.com/v1/hospitals/' + waitKeys[i] + '/waits';
+      var hospitalId = waitKeys[i];
+      if (!hospitalId) return;
+      currentCluster = clusteredWaits[hospitalId];
+      queryUrl = 'https://api.clockwisemd.com/v1/hospitals/' + hospitalId + '/waits';
       $.ajax({
         url:    queryUrl,
         method: 'GET',


### PR DESCRIPTION
We had a cluster of 400s this morning from this request not containing a hospital ID. 

Should we log an error message here?