### PR TITLE
Switch to jQuery 3.4.1 in reference documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,10 @@ clinic with ID 293.
 <html>
   <head>
     <!-- Content in your head -->
-    <!-- ... -->
     <script
-        src="https://code.jquery.com/jquery-3.2.1.min.js"
-        integrity="sha256-hwg4gsxgFZhOsEEamdOYGBf13FyQuiTwlAQgxVSNgt4="
-        crossorigin="anonymous"></script>
+			  src="https://code.jquery.com/jquery-3.4.1.min.js"
+			  integrity="sha256-CSXorXvZcTkaix6Yvo6HppcZGetbYMGWSFlBw8HfCJo="
+			  crossorigin="anonymous"></script><!-- ... -->
     <script src="https://s3-us-west-1.amazonaws.com/clockwisepublic/clockwiseWaitTimes.min.js"></script>
   </head>
   <body>
@@ -112,9 +111,9 @@ hospital.
     <!-- Content in your head -->
     <!-- ... -->
     <script
-        src="https://code.jquery.com/jquery-3.2.1.min.js"
-        integrity="sha256-hwg4gsxgFZhOsEEamdOYGBf13FyQuiTwlAQgxVSNgt4="
-        crossorigin="anonymous"></script>
+			  src="https://code.jquery.com/jquery-3.4.1.min.js"
+			  integrity="sha256-CSXorXvZcTkaix6Yvo6HppcZGetbYMGWSFlBw8HfCJo="
+			  crossorigin="anonymous"></script><!-- ... -->
     <script src="https://s3-us-west-1.amazonaws.com/clockwisepublic/clockwiseWaitTimes.min.js"></script>
   </head>
   <body>
@@ -179,9 +178,9 @@ range.
     <!-- Content in your head -->
     <!-- ... -->
     <script
-        src="https://code.jquery.com/jquery-3.2.1.min.js"
-        integrity="sha256-hwg4gsxgFZhOsEEamdOYGBf13FyQuiTwlAQgxVSNgt4="
-        crossorigin="anonymous"></script>
+			  src="https://code.jquery.com/jquery-3.4.1.min.js"
+			  integrity="sha256-CSXorXvZcTkaix6Yvo6HppcZGetbYMGWSFlBw8HfCJo="
+			  crossorigin="anonymous"></script><!-- ... -->
     <script src="https://s3-us-west-1.amazonaws.com/clockwisepublic/clockwiseWaitTimes.min.js"></script>
   </head>
   <body>

--- a/index.html
+++ b/index.html
@@ -2,9 +2,9 @@
 <html>
   <head>
     <script
-			  src="https://code.jquery.com/jquery-3.2.1.min.js"
-			  integrity="sha256-hwg4gsxgFZhOsEEamdOYGBf13FyQuiTwlAQgxVSNgt4="
-			  crossorigin="anonymous"></script>
+			  src="https://code.jquery.com/jquery-3.4.1.min.js"
+			  integrity="sha256-CSXorXvZcTkaix6Yvo6HppcZGetbYMGWSFlBw8HfCJo="
+			  crossorigin="anonymous"></script><!-- ... -->
     <script src="https://s3-us-west-1.amazonaws.com/clockwisepublic/clockwiseWaitTimes.js"></script>
   </head>
   <body>


### PR DESCRIPTION
v3.2.1 is coming up on 2 years old now and is more likely to conflict with newer versions of otherwise unrelated packages on customers' websites.  Since we make relatively little use of jQuery anyway there shouldn't be any impact moving to a different version.